### PR TITLE
ci: add Node.js workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: fe-ci
+on:
+  push: { branches: [ main ] }
+  pull_request: { branches: [ main ] }
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm   # cần có package-lock.json
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
Setup GitHub Actions to install Node 20, use npm cache, run npm ci and build. Triggers on PR to main and manual dispatch.